### PR TITLE
fix rut formatting

### DIFF
--- a/lib/struct.ex
+++ b/lib/struct.ex
@@ -33,9 +33,14 @@ defmodule ElixirCLRut.Struct do
     # 1 - First we strip all non valid characters
     normalized = Formatter.normalize(input)
 
-    # 2 - If the string includes checkdigit we remove the last char
+    # 2 - Determine if the last char is a check digit (handle 8+1 case)
+    treat_last_as_checkdigit =
+      dashed? or
+        includes_checkdigit? or
+        (length(normalized) == 9 and Enum.all?(Enum.slice(normalized, 0, 8), &is_integer/1))
+
     normalized_no_checkdigit =
-      case dashed? or includes_checkdigit? do
+      case treat_last_as_checkdigit do
         true ->
           CheckDigit.remove(normalized)
 
@@ -47,7 +52,7 @@ defmodule ElixirCLRut.Struct do
     checkdigit = CheckDigit.get(normalized_no_checkdigit)
 
     lastdigit =
-      case dashed? or includes_checkdigit? do
+      case treat_last_as_checkdigit do
         true ->
           to_string(List.last(normalized))
 
@@ -62,7 +67,7 @@ defmodule ElixirCLRut.Struct do
       lastdigit: lastdigit,
       normalized: normalized_no_checkdigit,
       normalized_with_checkdigit: normalized,
-      dashed?: dashed? or includes_checkdigit?
+      dashed?: treat_last_as_checkdigit
     }
   end
 end

--- a/test/lib/formatter_test.exs
+++ b/test/lib/formatter_test.exs
@@ -1,4 +1,45 @@
 defmodule ElixirCLRutFormatterTest do
   use ExUnit.Case, async: true
   doctest ElixirCLRut.Formatter, import: true
+
+  alias ElixirCLRut.Formatter
+  alias ElixirCLRut
+
+  describe "format/2" do
+    test "formats a normalized RUT struct with default separator" do
+      rut = ElixirCLRut.from("20961605-K")
+      assert Formatter.format(rut) == "20.961.605-K"
+
+      assert ElixirCLRut.format("141231553", separator: "") == "14123155-3"
+    end
+
+    test "formats a normalized RUT struct with custom separator" do
+      rut = ElixirCLRut.from("20961605-K")
+      assert Formatter.format(rut, separator: ",") == "20,961,605-K"
+    end
+  end
+
+  describe "dots/3" do
+    test "adds dots to a list of rut characters" do
+      assert Formatter.dots([2, 0, 9, 6, 1, 6, 0, 5]) == "20.961.605"
+      assert Formatter.dots([2, 0, 9, 6, 1, 6, 0, 5], ",") == "20,961,605"
+      assert Formatter.dots([2, 0, 9, 6, 1, 6, 0, 5], ",", 3) == "20,961,605"
+    end
+  end
+
+  describe "clean/1" do
+    test "removes all chars except numbers and K" do
+      assert Formatter.clean("2228250-6") == "22282506"
+      assert Formatter.clean("14.193.432-5") == "141934325"
+      assert Formatter.clean("12.345.678-k") == "12345678k"
+    end
+  end
+
+  describe "normalize/1" do
+    test "transforms a RUT string to a list of numbers" do
+      assert Formatter.normalize("2228250-6") == [2, 2, 2, 8, 2, 5, 0, 6]
+      assert Formatter.normalize("14.193.432-5") == [1, 4, 1, 9, 3, 4, 3, 2, 5]
+      assert Formatter.normalize("12.345.678-k") == [1, 2, 3, 4, 5, 6, 7, 8, "K"]
+    end
+  end
 end


### PR DESCRIPTION
This pull request introduces a refinement in the logic for handling RUT (Rol Único Tributario) validation and formatting in `lib/struct.ex` and adds comprehensive test coverage for the `Formatter` module in `test/lib/formatter_test.exs`. The changes improve the clarity of the code and ensure correctness in edge cases, such as handling RUTs with or without check digits.

### Refinements to RUT validation logic:
* Introduced a new `treat_last_as_checkdigit` variable to centralize the logic for determining whether the last character of a RUT should be treated as a check digit. This replaces repetitive conditions in multiple places. (`lib/struct.ex`, [[1]](diffhunk://#diff-fd01ba0fb036d427369036f3e58a36cae7b1fb826accb435ad2fb356309ea80fL36-R43) [[2]](diffhunk://#diff-fd01ba0fb036d427369036f3e58a36cae7b1fb826accb435ad2fb356309ea80fL50-R55) [[3]](diffhunk://#diff-fd01ba0fb036d427369036f3e58a36cae7b1fb826accb435ad2fb356309ea80fL65-R70)

### Addition of test coverage:
* Added unit tests for the `Formatter` module to validate its behavior, including:
  - Formatting RUTs with default and custom separators. (`test/lib/formatter_test.exs`, [test/lib/formatter_test.exsR4-R44](diffhunk://#diff-e12cbc0260a322825654702edafba8df107a2d5b6d46c6a6410e495484731d68R4-R44))
  - Adding dots to RUT characters. (`test/lib/formatter_test.exs`, [test/lib/formatter_test.exsR4-R44](diffhunk://#diff-e12cbc0260a322825654702edafba8df107a2d5b6d46c6a6410e495484731d68R4-R44))
  - Cleaning RUT strings by removing invalid characters. (`test/lib/formatter_test.exs`, [test/lib/formatter_test.exsR4-R44](diffhunk://#diff-e12cbc0260a322825654702edafba8df107a2d5b6d46c6a6410e495484731d68R4-R44))
  - Normalizing RUT strings into a list of numbers and characters. (`test/lib/formatter_test.exs`, [test/lib/formatter_test.exsR4-R44](diffhunk://#diff-e12cbc0260a322825654702edafba8df107a2d5b6d46c6a6410e495484731d68R4-R44))